### PR TITLE
chore: rename conducted_finance_projects to align with hsfp requirements

### DIFF
--- a/src/app/visa/b.spec.ts
+++ b/src/app/visa/b.spec.ts
@@ -216,14 +216,14 @@ describe('Visa type B point simulation', () => {
 
       it('conducted financed projects', () => {
         const checklist = simulationWithCriteria([
-          researchAchievementOf({ kind: 'conducted_financed_projects' }),
+          researchAchievementOf({ kind: 'conducted_financed_projects_three_times' }),
         ])
 
         const { matches, points } = calculatePoints(checklist)
 
         expect(points).toBe(15)
         expect(matches.map(m => m.id).sort()).toEqual([
-          'conducted_financed_projects',
+          'conducted_financed_projects_three_times',
         ])
       })
 

--- a/src/app/visa/b.ts
+++ b/src/app/visa/b.ts
@@ -162,7 +162,7 @@ export const matchersForVisaB: {
   RESEARCH_ACHIEVEMENTS: {
     criteria: [
       { id: 'patent_inventor', points: 15 },
-      { id: 'conducted_financed_projects', points: 15 },
+      { id: 'conducted_financed_projects_three_times', points: 15 },
       { id: 'has_published_three_papers', points: 15 },
       { id: 'research_recognized_by_japan', points: 15 },
     ],


### PR DESCRIPTION
what:
rename to conform with requirements and avoid confusion (requirement states for minimum of 3 times for financing projects before the points are counted)