### PR TITLE
Add mobile sidebar navigation for site header

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -3,7 +3,13 @@
 import { useState } from 'react'
 import { Logo } from '@components/Logo'
 import { SettingsModal } from '@components/SettingsModal'
-import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import {
+  Bars3Icon,
+  Cog6ToothIcon,
+  HomeIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
 import { useTranslations } from 'next-intl'
 import Link from 'next-intl/link'
 import { usePathname } from 'next/navigation'
@@ -12,6 +18,7 @@ export function SiteHeader() {
   const pathname = usePathname()
   const t = useTranslations('nav')
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   // Hide header on calculator form pages, but show on intro and results pages
   const isIntroPage = pathname.match(/\/calculator\/[^/]+$/)
@@ -30,6 +37,11 @@ export function SiteHeader() {
     return null
   }
 
+  const handleOpenSettings = () => {
+    setIsMobileMenuOpen(false)
+    setIsSettingsOpen(true)
+  }
+
   return (
     <>
       <div className="max-w-7xl mx-auto">
@@ -40,7 +52,9 @@ export function SiteHeader() {
           >
             <Logo />
           </Link>
-          <nav className="flex items-center gap-4">
+
+          {/* Desktop navigation */}
+          <nav className="hidden md:flex items-center gap-4">
             <ul className="flex space-x-4 items-center justify-center h-full font-semibold text-lg">
               <li>
                 <Link
@@ -67,8 +81,87 @@ export function SiteHeader() {
               <Cog6ToothIcon className="w-6 h-6" />
             </button>
           </nav>
+
+          {/* Mobile menu button */}
+          <button
+            onClick={() => setIsMobileMenuOpen(true)}
+            className="md:hidden p-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-gray-50 transition-colors"
+            aria-label={t('menu')}
+          >
+            <Bars3Icon className="w-6 h-6" />
+          </button>
         </header>
       </div>
+
+      {/* Mobile sidebar overlay */}
+      {isMobileMenuOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/50 z-40"
+          onClick={() => setIsMobileMenuOpen(false)}
+        />
+      )}
+
+      {/* Mobile sidebar */}
+      <aside
+        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-white dark:bg-zinc-900 z-50 transform transition-transform duration-200 ease-in-out ${
+          isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <div className="flex flex-col h-full">
+          <div className="flex justify-end p-4 border-b border-zinc-200 dark:border-zinc-800">
+            <button
+              onClick={() => setIsMobileMenuOpen(false)}
+              className="p-2 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-gray-50 transition-colors"
+              aria-label={t('close')}
+            >
+              <XMarkIcon className="w-6 h-6" />
+            </button>
+          </div>
+
+          <nav className="flex-1 p-4">
+            <ul className="space-y-2">
+              <li>
+                <Link
+                  href={`/`}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className={`flex items-center gap-3 px-4 py-3 rounded-lg no-underline text-lg font-medium transition-colors ${
+                    isHomePage
+                      ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                      : 'text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                  }`}
+                >
+                  <HomeIcon className="w-5 h-5" />
+                  {t('home')}
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={`/about`}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className={`flex items-center gap-3 px-4 py-3 rounded-lg no-underline text-lg font-medium transition-colors ${
+                    isAboutPage
+                      ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                      : 'text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                  }`}
+                >
+                  <InformationCircleIcon className="w-5 h-5" />
+                  {t('about')}
+                </Link>
+              </li>
+              <li>
+                <button
+                  onClick={handleOpenSettings}
+                  className="flex items-center gap-3 px-4 py-3 rounded-lg text-lg font-medium transition-colors text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 w-full text-left"
+                >
+                  <Cog6ToothIcon className="w-5 h-5" />
+                  {t('settings')}
+                </button>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+
       <SettingsModal
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -150,7 +150,9 @@
   "nav": {
     "home": "Home",
     "about": "About",
-    "settings": "Settings"
+    "settings": "Settings",
+    "menu": "Menu",
+    "close": "Close menu"
   },
   "settings": {
     "title": "Settings",

--- a/src/lib/i18n/messages/ja.json
+++ b/src/lib/i18n/messages/ja.json
@@ -150,7 +150,9 @@
   "nav": {
     "home": "ホーム",
     "about": "このサイトについて",
-    "settings": "設定"
+    "settings": "設定",
+    "menu": "メニュー",
+    "close": "メニューを閉じる"
   },
   "settings": {
     "title": "設定",

--- a/src/lib/i18n/messages/zh-CN.json
+++ b/src/lib/i18n/messages/zh-CN.json
@@ -150,7 +150,9 @@
   "nav": {
     "home": "首页",
     "about": "关于本站",
-    "settings": "设置"
+    "settings": "设置",
+    "menu": "菜单",
+    "close": "关闭菜单"
   },
   "settings": {
     "title": "设置",

--- a/src/lib/i18n/messages/zh-TW.json
+++ b/src/lib/i18n/messages/zh-TW.json
@@ -150,7 +150,9 @@
   "nav": {
     "home": "首頁",
     "about": "關於本站",
-    "settings": "設定"
+    "settings": "設定",
+    "menu": "選單",
+    "close": "關閉選單"
   },
   "settings": {
     "title": "設定",


### PR DESCRIPTION
On mobile, the header navigation is now shown as an expandable sidebar
menu from the right side. Includes Home, About, and Settings with icons
and labels. Desktop navigation remains unchanged.