### PR TITLE
Fix results page styling issues

### DIFF
--- a/src/app/[locale]/calculator/[visa]/(form)/results/ResultsClient.tsx
+++ b/src/app/[locale]/calculator/[visa]/(form)/results/ResultsClient.tsx
@@ -235,7 +235,7 @@ function MatchesOverview({
               <th className="text-left py-3 px-4 font-semibold text-zinc-700 dark:text-zinc-300">
                 {t('overview.explanation')}
               </th>
-              <th className="text-right py-3 px-4 font-semibold text-zinc-700 dark:text-zinc-300">
+              <th className="text-right py-3 px-4 font-semibold text-zinc-700 dark:text-zinc-300 whitespace-nowrap">
                 {t('overview.points')}
               </th>
             </tr>
@@ -396,7 +396,7 @@ function CollapsibleEvidenceCategory({
     <div className="border border-zinc-100 dark:border-zinc-900 rounded-lg overflow-hidden">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between p-4 text-left bg-white dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+        className="w-full flex items-center justify-between p-4 text-left bg-zinc-100 dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
       >
         <div className="flex items-center gap-3">
           {isOpen ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,7 @@ a {
   }
 
   .button:not(.secondary) {
-    @apply px-4 h-12 md:h-9 flex items-center rounded bg-white text-zinc-900 font-bold whitespace-nowrap shadow-sm relative outline-2 outline outline-transparent;
+    @apply px-4 h-12 md:h-9 flex items-center rounded bg-white text-zinc-900 font-bold whitespace-nowrap shadow-sm relative outline-2 outline outline-transparent ring-1 ring-zinc-300 dark:ring-0;
     @apply hover:outline-emerald-400/80 hover:bg-zinc-50 focus-visible:outline-emerald-400/80 active:scale-95 transition-all;
   }
 


### PR DESCRIPTION
- Use bg-zinc-100 for evidence checklist headers in light mode to match
  results table headings
- Add whitespace-nowrap to points column header to prevent line breaks