### PR TITLE
Add GitHub repository link to site footer

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -27,6 +27,14 @@ export function SiteFooter() {
         >
           {t('privacy')}
         </Link>
+        <a
+          href="https://github.com/antonve/hsfp.tokyo"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+        >
+          GitHub
+        </a>
         <span>{t('last_updated')}</span>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
Added a link to the GitHub repository in the site footer to improve discoverability and encourage community contributions.

## Changes
- Added a new GitHub link in the `SiteFooter` component that points to the project repository (https://github.com/antonve/hsfp.tokyo)
- Link opens in a new tab with `target="_blank"` and includes security attributes (`rel="noopener noreferrer"`)
- Styled with consistent hover effects matching the existing footer links (zinc-700 in light mode, zinc-300 in dark mode)
- Positioned between the Privacy link and the "Last Updated" text

## Implementation Details
- Uses the same styling pattern as other footer links for visual consistency
- Includes proper accessibility attributes for external links
- Maintains the existing footer layout and responsive design