### PR TITLE
Add loading state to visa form prompts with disabled buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,11 @@ a {
     @apply hover:outline-emerald-400/80 hover:bg-zinc-50 focus-visible:outline-emerald-400/80 active:scale-95 transition-all;
   }
 
+  .button:not(.secondary):disabled {
+    @apply bg-zinc-100 text-zinc-400 cursor-not-allowed;
+    @apply hover:outline-transparent hover:bg-zinc-100 active:scale-100;
+  }
+
   .button.secondary {
     @apply px-4 h-12 md:h-9 flex items-center rounded whitespace-nowrap relative outline outline-2 outline-transparent;
     @apply bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300;

--- a/src/components/BooleanPrompt.tsx
+++ b/src/components/BooleanPrompt.tsx
@@ -15,6 +15,7 @@ export function BooleanPrompt({
   prompt,
   overallPromptIndex,
   onSubmit,
+  isLoading = false,
 }: {
   qualifications: Qualifications
   visaType: VisaType
@@ -22,6 +23,7 @@ export function BooleanPrompt({
   prompt: BooleanPromptType
   overallPromptIndex: number
   onSubmit: (updateQualifications: QualificationUpdater) => void
+  isLoading?: boolean
 }) {
   return (
     <ChoicePrompt
@@ -39,6 +41,7 @@ export function BooleanPrompt({
       })}
       visaType={visaType}
       section={section}
+      isLoading={isLoading}
     />
   )
 }

--- a/src/components/ChoicePrompt.tsx
+++ b/src/components/ChoicePrompt.tsx
@@ -26,6 +26,7 @@ export function ChoicePrompt({
     ...withCompletedPrompt(overallPromptIndex, q),
     [prompt.id]: value,
   }),
+  isLoading = false,
 }: {
   qualifications: Qualifications
   visaType: VisaType
@@ -34,6 +35,7 @@ export function ChoicePrompt({
   overallPromptIndex: number
   onSubmit: (updateQualifications: QualificationUpdater) => void
   qualificationUpdater?: (value: string) => QualificationUpdater
+  isLoading?: boolean
 }) {
   const [value, setValue] = useState<string | undefined>(() => {
     if (isPromptCompleted(overallPromptIndex, qualifications)) {
@@ -153,13 +155,23 @@ export function ChoicePrompt({
         ))}
       </div>
       <div className="flex flex-wrap -m-2">
-        <button type="submit" className="button m-2">
-          {t(`actions.continue`)}
-          <ArrowRightIcon className="h-5 w-5 ml-2" />
+        <button type="submit" className="button m-2" disabled={isLoading}>
+          <span className={isLoading ? 'invisible' : ''}>
+            {t(`actions.continue`)}
+          </span>
+          <ArrowRightIcon
+            className={`h-5 w-5 ml-2 ${isLoading ? 'invisible' : ''}`}
+          />
+          {isLoading && (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="h-5 w-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+            </span>
+          )}
         </button>
         <button
           type="button"
           className="button secondary m-2"
+          disabled={isLoading}
           onClick={() =>
             onSubmit(q => ({
               ...withCompletedPrompt(overallPromptIndex, q),

--- a/src/components/NumberPrompt.tsx
+++ b/src/components/NumberPrompt.tsx
@@ -18,6 +18,7 @@ export function NumberPrompt({
   qualifications,
   visaType,
   section,
+  isLoading = false,
 }: {
   qualifications: Qualifications
   visaType: VisaType
@@ -25,6 +26,7 @@ export function NumberPrompt({
   prompt: NumberPromptType
   overallPromptIndex: number
   onSubmit: (updateQualifications: QualificationUpdater) => void
+  isLoading?: boolean
 }) {
   const [value, setValue] = useState<number | undefined>(() => {
     if (isPromptCompleted(overallPromptIndex, qualifications)) {
@@ -159,14 +161,23 @@ export function NumberPrompt({
       </div>
 
       <div className="flex flex-wrap -m-2">
-        <button type="submit" className="button m-2">
-          {t(`actions.continue`)}
-          <ArrowRightIcon className="h-5 w-5 ml-2" />
+        <button type="submit" className="button m-2" disabled={isLoading}>
+          <span className={isLoading ? 'invisible' : ''}>
+            {t(`actions.continue`)}
+          </span>
+          <ArrowRightIcon
+            className={`h-5 w-5 ml-2 ${isLoading ? 'invisible' : ''}`}
+          />
+          {isLoading && (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="h-5 w-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+            </span>
+          )}
         </button>
         <button
           type="button"
           className="button secondary m-2"
-          disabled={prompt.required}
+          disabled={prompt.required || isLoading}
           title={prompt.required ? t(`actions.cannot_skip_hint`) : undefined}
           onClick={() =>
             onSubmit(q => ({

--- a/src/components/VisaFormPrompt.tsx
+++ b/src/components/VisaFormPrompt.tsx
@@ -15,6 +15,7 @@ export function VisaFormPrompt({
   prompt,
   overallPromptIndex,
   onSubmit,
+  isLoading,
 }: {
   qualifications: Qualifications
   visaType: VisaType
@@ -22,6 +23,7 @@ export function VisaFormPrompt({
   prompt: Prompt
   overallPromptIndex: number
   onSubmit: (updateQualifications: QualificationUpdater) => void
+  isLoading: boolean
 }) {
   switch (prompt.type) {
     case 'NUMBER':
@@ -34,6 +36,7 @@ export function VisaFormPrompt({
             visaType={visaType}
             section={section}
             overallPromptIndex={overallPromptIndex}
+            isLoading={isLoading}
           />
         </div>
       )
@@ -47,6 +50,7 @@ export function VisaFormPrompt({
             visaType={visaType}
             section={section}
             overallPromptIndex={overallPromptIndex}
+            isLoading={isLoading}
           />
         </div>
       )
@@ -60,6 +64,7 @@ export function VisaFormPrompt({
             visaType={visaType}
             section={section}
             overallPromptIndex={overallPromptIndex}
+            isLoading={isLoading}
           />
         </div>
       )

--- a/src/components/VisaFormSection.tsx
+++ b/src/components/VisaFormSection.tsx
@@ -14,7 +14,7 @@ import { FrequentlyAskedQuestions } from '@components/FrequentlyAskedQuestions'
 import { useParams, useRouter } from 'next/navigation'
 import { useLanguage } from '@lib/hooks'
 import { useTranslations } from 'next-intl'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { withCompletedPrompt } from '@lib/domain/prompts'
 import { ChevronDoubleRightIcon } from '@heroicons/react/20/solid'
 
@@ -47,8 +47,10 @@ export function VisaFormSection({
   const translationPrefix = `visa_form.${config.visaType}.sections.${progress.section}.${prompt.id}`
 
   const formRef = useRef<HTMLDivElement>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   const submit = (updateQualifications: QualificationUpdater) => {
+    setIsLoading(true)
     const newQualifications = updateQualifications(qualifications)
     const { section, promptIndex, finished } = nextStepOfForm(
       config,
@@ -148,6 +150,7 @@ export function VisaFormSection({
           section={progress.section}
           visaType={config.visaType}
           overallPromptIndex={overallPromptIndex}
+          isLoading={isLoading}
         />
         <FrequentlyAskedQuestions
           count={prompt.faqCount ?? 0}


### PR DESCRIPTION
## Summary
This PR adds a loading state to visa form prompts to prevent duplicate submissions and improve user experience. When a form is being submitted, buttons are disabled and a loading spinner is displayed on the submit button.

## Key Changes
- **Styling**: Added disabled state styling for primary buttons in `globals.css` with a muted appearance and disabled cursor
- **Loading State Management**: Introduced `isLoading` state in `VisaFormSection` component that is set to `true` when a form submission begins
- **Button Behavior**: 
  - Submit buttons now display a spinning loader icon instead of text when `isLoading` is true
  - Both submit and secondary (skip) buttons are disabled during loading to prevent multiple submissions
  - For `NumberPrompt`, the skip button respects both the `required` flag and loading state
- **Component Updates**: Propagated `isLoading` prop through the component hierarchy:
  - `VisaFormSection` → `VisaFormPrompt` → `NumberPrompt`, `ChoicePrompt`, `BooleanPrompt`

## Implementation Details
- The loading spinner uses a CSS animation (`animate-spin`) with a border-based design
- The `isLoading` state is managed at the `VisaFormSection` level and passed down to all prompt components
- Button disabled states prevent user interaction while the form submission is in progress
- The implementation maintains backward compatibility with optional `isLoading` parameters (defaulting to `false`)