### PR TITLE
Use system theme preference when no stored theme exists

### DIFF
--- a/src/lib/ThemeContext.tsx
+++ b/src/lib/ThemeContext.tsx
@@ -24,13 +24,19 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('light')
   const [mounted, setMounted] = useState(false)
 
-  // Load theme from localStorage on mount
+  // Load theme from localStorage on mount, or use system preference
   useEffect(() => {
     setMounted(true)
     try {
       const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
       if (stored === 'light' || stored === 'dark') {
         setThemeState(stored)
+      } else {
+        // No stored preference, use system preference
+        const prefersDark = window.matchMedia(
+          '(prefers-color-scheme: dark)',
+        ).matches
+        setThemeState(prefersDark ? 'dark' : 'light')
       }
     } catch {
       // Ignore localStorage errors


### PR DESCRIPTION
## Summary
Enhanced the theme initialization logic to respect the user's system color scheme preference when no stored theme preference exists in localStorage.

## Changes
- Modified `ThemeProvider` to check system `prefers-color-scheme` media query when localStorage has no saved theme
- Falls back to system preference (dark/light) instead of defaulting to 'light' theme
- Improves user experience by honoring OS-level theme settings on first visit

## Implementation Details
- Uses `window.matchMedia('(prefers-color-scheme: dark)')` to detect system preference
- Only applies system preference when localStorage is empty or contains invalid data
- Maintains existing behavior of respecting stored user preferences when available
- Error handling for localStorage access remains unchanged